### PR TITLE
Feat: specify node-proxy image from ConfigMap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,13 @@ deploy: generate
 ifeq ($(uname), Darwin)
 	sed -i '' -e 's@image: .*@image: '"${IMG_AGENT}"'@' ./config/${BRANCH}/agent_image_patch.yaml
 	sed -i '' -e 's@image: .*@image: '"${IMG_MANAGER}"'@' ./config/${BRANCH}/manager_image_patch.yaml
-	sed -i '' -e 's@NodeProxyForwardImage             string = \".*\"@NodeProxyForwardImage             string = \"'"${IMG_FORWARD}"'\"@' ./pkg/constant/constants.go
-	sed -i '' -e 's@NodeProxyProxyImage               string = \".*\"@NodeProxyProxyImage               string = \"'"${IMG_PROXY}"'\"@' ./pkg/constant/constants.go
+	sed -i '' -e 's@NodeProxyDefaultForwardImage      string = \".*\"@NodeProxyDefaultForwardImage      string = \"'"${IMG_FORWARD}"'\"@' ./pkg/constant/constants.go
+	sed -i '' -e 's@NodeProxyDefaultProxyImage        string = \".*\"@NodeProxyDefaultProxyImage        string = \"'"${IMG_PROXY}"'\"@' ./pkg/constant/constants.go
 else
 	sed -i -e 's@image: .*@image: '"${IMG_AGENT}"'@' ./config/${BRANCH}/agent_image_patch.yaml
 	sed -i -e 's@image: .*@image: '"${IMG_MANAGER}"'@' ./config/${BRANCH}/manager_image_patch.yaml
-	sed -i -e 's@NodeProxyForwardImage             string = \".*\"@NodeProxyForwardImage             string = \"'"${IMG_FORWARD}"'\"@' ./pkg/constant/constants.go
-	sed -i -e 's@NodeProxyProxyImage               string = \".*\"@NodeProxyProxyImage               string = \"'"${IMG_PROXY}"'\"@' ./pkg/constant/constants.go
+	sed -i -e 's@NodeProxyDefaultForwardImage      string = \".*\"@NodeProxyDefaultForwardImage      string = \"'"${IMG_FORWARD}"'\"@' ./pkg/constant/constants.go
+	sed -i -e 's@NodeProxyDefaultProxyImage        string = \".*\"@NodeProxyDefaultProxyImage        string = \"'"${IMG_PROXY}"'\"@' ./pkg/constant/constants.go
 endif
 	kustomize build config/${BRANCH} -o deploy/porter.yaml
 	@echo "Done, the yaml is in deploy folder named 'porter.yaml'"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -45,6 +45,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   verbs:
   - get

--- a/deploy/porter.yaml
+++ b/deploy/porter.yaml
@@ -810,6 +810,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   verbs:
   - get

--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -19,13 +19,16 @@ const (
 	LabelNodeProxyExcludeNode         string = "node-proxy.porter.kubesphere.io/exclude-node"
 	NodeProxyExternalIPAnnotationKey  string = "node-proxy.porter.kubesphere.io/external-ip"
 	NodeProxyInternalIPAnnotationKey  string = "node-proxy.porter.kubesphere.io/internal-ip"
-	NodeProxyForwardImage             string = "kubespheredev/openelb-forward:v0.4.2"
-	NodeProxyProxyImage               string = "kubespheredev/openelb-proxy:v0.4.2"
+	NodeProxyDefaultForwardImage      string = "kubespheredev/openelb-forward:v0.4.2"
+	NodeProxyDefaultProxyImage        string = "kubespheredev/openelb-proxy:v0.4.2"
 	NameSeparator                     string = "-"
 	IPSeparator                       string = ","
 	EnvArgSplitter                    string = " "
 	NodeProxyWorkloadPrefix           string = "node-proxy-"
 	NodeProxyFinalizerName            string = "node-proxy.porter.kubesphere.io/finalizer"
+	NodeProxyConfigMapName            string = "node-proxy-config"
+	NodeProxyConfigMapForwardImage    string = "forward-image"
+	NodeProxyConfigMapProxyImage      string = "proxy-image"
 
 	KubernetesMasterLabel string = "node-role.kubernetes.io/master"
 

--- a/pkg/controllers/lb/controller.go
+++ b/pkg/controllers/lb/controller.go
@@ -54,6 +54,7 @@ import (
 // +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=nodes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 
 // ServiceReconciler reconciles a Service object
 type ServiceReconciler struct {

--- a/pkg/controllers/lb/nodeporxy.go
+++ b/pkg/controllers/lb/nodeporxy.go
@@ -155,9 +155,9 @@ func (r *ServiceReconciler) newProxyPoTepl(svc *corev1.Service) *corev1.PodTempl
 	return res
 }
 
-// User can config NodeProxy by ConfigMap specifying the image
-// If the ConfigMap exists and the configuration is set, use this config
-// Otherwize, use the default image got from constans.
+// User can config NodeProxy by ConfigMap to specify the proxy and forward images
+// If the ConfigMap exists and the configuration is set, use it,
+// 	otherwise, use the default image got from constants.
 func (r *ServiceReconciler) getNPConfig() (*corev1.ConfigMap, error) {
 	NPCfgName := types.NamespacedName{Namespace: envNamespace(), Name: constant.NodeProxyConfigMapName}
 	cm := &corev1.ConfigMap{}


### PR DESCRIPTION
User can config NodeProxy by ConfigMap to specify the proxy and forward images.

If the ConfigMap exists and the configuration is set, use config in it.

Otherwise, use the default image got from constants.

Note: When the user created the ConfigMap, the image will be changed at once. 

The configuration sample can be found in #214 