### PR TITLE
change clusterrolebinding name

### DIFF
--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: porter-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/porter.yaml
+++ b/deploy/porter.yaml
@@ -981,7 +981,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: porter-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Signed-off-by: LiHui <andrewli@kubesphere.io>

Change the name of cluster role binding `manager-rolebinding` to `porter-manager-rolebinding`, because the name `manager-rolebinding` has been used by DevOps.